### PR TITLE
Fix `shelve2json` console script entrypoint

### DIFF
--- a/json_store/shelve2json.py
+++ b/json_store/shelve2json.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 # encoding: utf-8
 from __future__ import absolute_import, print_function, unicode_literals
 """Naïvely create a json_store file from a shelve DB."""
@@ -34,5 +33,9 @@ def main(argv):
         return 1
 
 
-if __name__ == '__main__':
+def run():
     sys.exit(main(sys.argv))
+
+
+if __name__ == '__main__':
+    run()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     packages=['json_store'],
     entry_points={
         'console_scripts': [
-            'shelve2json=json_store.shelve2json:main',
+            'shelve2json=json_store.shelve2json:run',
         ],
     },
     description="A shelve-like store using JSON serialization.",


### PR DESCRIPTION
Hi again,

this patch fixes an error I got when invoking the `shelve2json` program. The error was:
```python
TypeError: main() missing 1 required positional argument: 'argv'
```

With kind regards,
Andreas.
