### PR TITLE
Add support for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,10 +70,11 @@ jobs:
 
   test:
     needs: [lint, build]
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.10"]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -102,6 +103,7 @@ jobs:
           pip install --disable-pip-version-check pytest
 
       - name: Install json-store package
+        shell: bash # so this works on both Linux and Windows
         run: |
           pip install --disable-pip-version-check dist/json_store-*.whl
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,4 +111,5 @@ jobs:
         run: pytest
 
       - name: Test shelve2json
+        if: ${{ matrix.os != 'windows-latest' }} # shelve.open has an internal traceback on Windows
         run: sh tests/test_shelve2json.sh

--- a/json_store/json_store.py
+++ b/json_store/json_store.py
@@ -94,7 +94,7 @@ class JSONStore(MutableMapping):
             json.dump(self._data, fp, **json_kw)
         if self.mode != MODE_600:  # _mktemp uses 0600 by default
             os.chmod(fp.name, self.mode)
-        os.rename(fp.name, self.path)
+        os.replace(fp.name, self.path)
 
         self._synced_json_kw = json_kw
         self._needs_sync = False

--- a/tests/test_json_store.py
+++ b/tests/test_json_store.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import platform
 import shutil
 import stat
 from tempfile import NamedTemporaryFile
@@ -154,10 +155,11 @@ def test_set_mode():
     store = get_new_store(mode=int("640", 8))
     try:
         st_mode = os.stat(store.path).st_mode
+        is_windows = platform.system() == "Windows"
         assert st_mode & stat.S_IRUSR
         assert st_mode & stat.S_IWUSR
-        assert st_mode & stat.S_IRGRP
-        assert not st_mode & stat.S_IWGRP
-        assert not st_mode & stat.S_IROTH
+        assert st_mode & stat.S_IRGRP or is_windows
+        assert not st_mode & stat.S_IWGRP or is_windows
+        assert not st_mode & stat.S_IROTH or is_windows
     finally:
         os.remove(store.path)


### PR DESCRIPTION
* Use `os.replace()` instead of `os.rename()` to fix Windows issue
* Adds Windows to test matrix
* For now, `shelve2json` is not supported on Windows

Fixes #18
