### PR TITLE
Remove a bunch of old Python 2 compatible code

### DIFF
--- a/json_store/__init__.py
+++ b/json_store/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .json_store import JSONStore
 
 __version__ = "4.0"

--- a/json_store/json_store.py
+++ b/json_store/json_store.py
@@ -4,21 +4,10 @@
 This is for small stores. Everything is in memory and sync() always writes
 everything out to disk.
 """
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
+import json
 import os
+from collections.abc import MutableMapping
 from tempfile import NamedTemporaryFile
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    from collections import MutableMapping
 
 __all__ = ["JSONStore"]
 

--- a/json_store/shelve2json.py
+++ b/json_store/shelve2json.py
@@ -1,7 +1,5 @@
 #! /usr/bin/env python
 # encoding: utf-8
-from __future__ import absolute_import, print_function, unicode_literals
-
 """Naïvely create a json_store file from a shelve DB."""
 
 import os

--- a/tests/test_json_store.py
+++ b/tests/test_json_store.py
@@ -1,16 +1,10 @@
 # encoding: utf-8
-from __future__ import absolute_import, unicode_literals
-
+import json
 import os
 import platform
 import shutil
 import stat
 from tempfile import NamedTemporaryFile
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
 
 import json_store
 


### PR DESCRIPTION
We no longer support Python 2 🪦. Remove some of the ancient backwards compatible code lying within.